### PR TITLE
feat: Add configurable front matter fields and enhanced documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ Thumbs.db
 .coverage
 htmlcov/
 .tox/
+/Test/
 
 # Output files
 media/

--- a/uv.lock
+++ b/uv.lock
@@ -109,12 +109,6 @@ dependencies = [
     { name = "rich" },
 ]
 
-[package.optional-dependencies]
-test = [
-    { name = "pytest" },
-    { name = "pytest-cov" },
-]
-
 [package.dev-dependencies]
 test = [
     { name = "pytest" },
@@ -126,11 +120,8 @@ requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
     { name = "mammoth", specifier = ">=1.10.0" },
     { name = "markdownify", specifier = ">=1.2.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "rich", specifier = ">=14.1.0" },
 ]
-provides-extras = ["test"]
 
 [package.metadata.requires-dev]
 test = [


### PR DESCRIPTION
- Add --front-matter-fields CLI option for customizable YAML front matter
- Support selecting from: title, author, created, modified, source_file
- Default maintains backward compatibility (title, source_file)
- Enhanced README.md with new features and usage examples
- Updated .copilot/copilot.md with comprehensive feature documentation
- Added Quality Enhancements section documenting markdown linting
- All 43 tests pass with new functionality

Breaking changes: None (backward compatible)
New features: Configurable front matter field selection